### PR TITLE
fix: this usage of `s` is ambiguous

### DIFF
--- a/src/Page/GettingStarted.elm
+++ b/src/Page/GettingStarted.elm
@@ -328,8 +328,8 @@ routeParser : Parser (Page -> a) a
 routeParser =
     UrlParser.oneOf
         [ UrlParser.map Home top
-        , UrlParser.map GettingStarted (s "getting-started")
-        , UrlParser.map Modules (s "modules")
+        , UrlParser.map GettingStarted (UrlParser.s "getting-started")
+        , UrlParser.map Modules (UrlParser.s "modules")
         ]
 
 


### PR DESCRIPTION
The s is used by both Html.s and Url.Parser.s

![image](https://user-images.githubusercontent.com/31991339/77244516-d745a480-6c15-11ea-9ff4-06ad074c8579.png)
```


-- AMBIGUOUS NAME  C:\Users\Igor\Documents\sources\repos\com.olenitsj\src\Main.elm

This usage of `s` is ambiguous:

127|         , UrlParser.map GettingStarted (s "getting-started")
                                             ^
This name is exposed by 2 of your imports, so I am not sure which one to use:

    Html.s
    Url.Parser.s

I recommend using qualified names for imported values. I also recommend having
at most one `exposing (..)` per file to make name clashes like this less common
in the long run.

Note: Check out <https://elm-lang.org/0.19.1/imports> for more info on the
import syntax.

___________________________________________________________________________________________________
-- AMBIGUOUS NAME  C:\Users\Igor\Documents\sources\repos\com.olenitsj\src\Main.elm

This usage of `s` is ambiguous:

128|         , UrlParser.map Modules (s "modules")
                                      ^
This name is exposed by 2 of your imports, so I am not sure which one to use:

    Html.s
    Url.Parser.s

I recommend using qualified names for imported values. I also recommend having
at most one `exposing (..)` per file to make name clashes like this less common
in the long run.

Note: Check out <https://elm-lang.org/0.19.1/imports> for more info on the
```
import syntax.